### PR TITLE
Better detailview of PokemonSpecies

### DIFF
--- a/pokerole_irl/pokerole_app/models.py
+++ b/pokerole_irl/pokerole_app/models.py
@@ -148,12 +148,21 @@ class PokemonSpecies(models.Model):
     image_name = models.CharField(max_length=50)
 
     @property
+    def weight_kg(self):
+        return f"{self.weight} kg"
+
+    @property
     def weight_lbs(self):
-        return round(2.2*self.weight, 1)
+        return f"{round(2.2*self.weight, 1)} lbs"
+
+    @property
+    def height_m(self):
+        return f"{self.height} m"
 
     @property
     def height_ft(self):
-        return round(3.28*self.height, 1)
+        feet = round(3.28*self.height, 1)
+        return f"{int(feet//1)}\'{int((feet%1)*12)}\""
 
     def get_weaknesses_and_resistances(self):
         wr_primary = self.primary_type.get_weaknesses_and_resistances()
@@ -170,6 +179,13 @@ class PokemonSpecies(models.Model):
             return weak_res
         else:
             return wr_primary
+
+    @property
+    def types(self):
+        typ = str(self.primary_type)
+        if self.secondary_type:
+            typ += f", {self.secondary_type}"
+        return typ
 
     @property
     def weaknesses(self):

--- a/pokerole_irl/pokerole_app/templates/allspecies.html
+++ b/pokerole_irl/pokerole_app/templates/allspecies.html
@@ -36,7 +36,7 @@
                 <tr>
                     <td>{{ pokemon.number }}</td>
                     <td><img src="https://raw.githubusercontent.com/Willowlark/Pokerole-Data/master/images/BoxSprites/{{ pokemon.image_name }}"/></td>
-                    <td title="{{ pokemon.description }}">{{ pokemon }}</td>
+                    <td title="{{ pokemon.description }}"><a href="{% url "species" pokemon.pk %}">{{ pokemon }}</a></td>
                     <td title="Weaknesses: {{ pokemon.weaknesses }}; Resistances: {{ pokemon.resistances }}"><ul>
                             <li>{{ pokemon.primary_type }}</li>
                             {% if pokemon.secondary_type %}

--- a/pokerole_irl/pokerole_app/templates/species.html
+++ b/pokerole_irl/pokerole_app/templates/species.html
@@ -1,16 +1,144 @@
 {% load static %}
+{% load utilities %}
 
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="{% static 'styles.css' %}" rel="stylesheet">
+    <link href="{% static 'species-detail.css' %}" rel="stylesheet">
     <title>Pokerole_irl</title>
 </head>
 
 <body>
-    <h1>{{ pokemon.name }}</h1>
-    <img src="{{ pokemon.book_image }}"/>
-    <p>{{ pokemon.category }}</p>
-    <p>{{ pokemon.description }}</p>
+    <div class="species-detail">
+        <h1>#{{ pokemon.number }}: {{ pokemon.name }}</h1>
+        <div class="species-category">{{ pokemon.category }}</div>
+        <div class="details-container">
+            <img class="species-image" src="{{ pokemon.book_image }}"/>
+            <div class="species-description">
+                "{{ pokemon.description }}"
+                <div class="species-height-weight">
+                    <span>
+                        <div class="header">Height</div>
+                        <div>{{ pokemon.height_m }}/{{ pokemon.height_ft }}</div>
+                    </span>
+                    <span>
+                        <div class="header">Weight</div>
+                        <div>{{ pokemon.weight_kg }}/{{ pokemon.weight_lbs }}</div>
+                    </span>
+                </div>
+            </div>
+        </div>
+        
+        <div class="info-body">
+            <div class="column">
+                <table class="info-table">
+                    <tbody>
+                        <tr>
+                            <td>Type:</td>
+                            <td>{{ pokemon.types }}</td>
+                        </tr>
+                        <tr>
+                            <td>Ability:</td>
+                            <td><ul class="comma-list">
+                                {% for ability in pokemon.abilities.all %}
+                                <li title="{{ ability.effect }}">{{ ability.name }}</li>
+                                {% endfor %}
+                            </ul></td>
+                        </tr>
+                        <tr>
+                            <td>Hidden:</td>
+                            <td>{{ pokemon.hidden_ability }}</td>
+                        </tr>
+                        <tr>
+                            <td>Rec. rank:</td>
+                            <td>{{ pokemon.recommended_rank }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table class="stat-table">
+                    <tbody>
+                        <tr>
+                            <td>Base HP</td>
+                            <td><div class="hp-val">{{ pokemon.base_hp }}</div></td>
+                        </tr>
+                        <tr>
+                            <td>Strength</td>
+                            <td>{% stat_graphic pokemon.base_strength pokemon.max_strength %}</td>
+                        </tr>
+                        <tr>
+                            <td>Dexterity</td>
+                            <td>{% stat_graphic pokemon.base_dexterity pokemon.max_dexterity %}</td>
+                        </tr>
+                        <tr>
+                            <td>Vitality</td>
+                            <td>{% stat_graphic pokemon.base_vitality pokemon.max_vitality %}</td>
+                        </tr>
+                        <tr>
+                            <td>Special</td>
+                            <td>{% stat_graphic pokemon.base_special pokemon.max_special %}</td>
+                        </tr>
+                        <tr>
+                            <td>Insight</td>
+                            <td>{% stat_graphic pokemon.base_insight pokemon.max_insight %}</td>
+                        </tr>
+                    </tbody>
+                </table>
+                {% if evolutions.exists %}
+                <h2>Evolutions</h2>
+                <ul class="evolutions">
+                    {% for evolution in evolutions.all %}
+                    <li>
+                        <img src="{{ evolution.to_species.box_image }}"/>
+                        <div>
+                            <div>
+                                <a href="{% url "species" evolution.to_species.pk %}">{{ evolution.to_species.name }}</a>
+                            </div>
+                            <div class="evolution-details">
+                                <span>{{ evolution.kind }}</span><span>{{ evolution.speed }}</span>
+                            </div>
+                        </div>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+                {% if preevolution.exists %}
+                <h2>Pre-evolution</h2>
+                <ul class="evolutions">
+                    {% for preevolution in preevolution.all %}
+                    <li>
+                        <img src="{{ preevolution.from_species.box_image }}"/>
+                        <div>
+                            <div>
+                                <a href="{% url "species" preevolution.from_species.pk %}">{{ preevolution.from_species.name }}</a>
+                            </div>
+                            <div class="evolution-details">
+                                <span>{{ preevolution.kind }}</span><span>{{ preevolution.speed }}</span>
+                            </div>
+                        </div>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </div>
+            <div class="column">
+                <table class="move-table">
+                    <tbody>
+                        <tr>
+                            <th>Move</th>
+                            <th>Rank</th>
+                        </tr>
+                        {% for move in moveset %}
+                        <tr>
+                            <td>{{ move.move.name }}</td>
+                            <td>{{ move.learned }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <a class="back-link" href="{% url "all_species" %}"><< Back to species</a>
+    </div>
 </body>

--- a/pokerole_irl/pokerole_app/templates/species.html
+++ b/pokerole_irl/pokerole_app/templates/species.html
@@ -18,6 +18,12 @@
             <img class="species-image" src="{{ pokemon.book_image }}"/>
             <div class="species-description">
                 "{{ pokemon.description }}"
+                {% if pokemon.good_starter %}
+                    <p class="other-info">Good starter</p>
+                {% endif %}
+                {% if pokemon.legendary %}
+                    <p class="other-info">Legendary</p>
+                {% endif %}
                 <div class="species-height-weight">
                     <span>
                         <div class="header">Height</div>
@@ -49,7 +55,7 @@
                         </tr>
                         <tr>
                             <td>Hidden:</td>
-                            <td>{{ pokemon.hidden_ability }}</td>
+                            <td title="{{ pokemon.hidden_ability.effect }}">{{ pokemon.hidden_ability }}</td>
                         </tr>
                         <tr>
                             <td>Rec. rank:</td>
@@ -64,24 +70,34 @@
                             <td><div class="hp-val">{{ pokemon.base_hp }}</div></td>
                         </tr>
                         <tr>
-                            <td>Strength</td>
-                            <td>{% stat_graphic pokemon.base_strength pokemon.max_strength %}</td>
+                            <td colspan="2">Strength</td>
                         </tr>
                         <tr>
-                            <td>Dexterity</td>
-                            <td>{% stat_graphic pokemon.base_dexterity pokemon.max_dexterity %}</td>
+                            <td colspan="2">{% stat_graphic pokemon.base_strength pokemon.max_strength %}</td>
                         </tr>
                         <tr>
-                            <td>Vitality</td>
-                            <td>{% stat_graphic pokemon.base_vitality pokemon.max_vitality %}</td>
+                            <td colspan="2">Dexterity</td>
                         </tr>
                         <tr>
-                            <td>Special</td>
-                            <td>{% stat_graphic pokemon.base_special pokemon.max_special %}</td>
+                            <td colspan="2">{% stat_graphic pokemon.base_dexterity pokemon.max_dexterity %}</td>
                         </tr>
                         <tr>
-                            <td>Insight</td>
-                            <td>{% stat_graphic pokemon.base_insight pokemon.max_insight %}</td>
+                            <td colspan="2">Vitality</td>
+                        </tr>
+                        <tr>
+                            <td colspan="2">{% stat_graphic pokemon.base_vitality pokemon.max_vitality %}</td>
+                        </tr>
+                        <tr>
+                            <td colspan="2">Special</td>
+                        </tr>
+                        <tr>
+                            <td colspan="2">{% stat_graphic pokemon.base_special pokemon.max_special %}</td>
+                        </tr>
+                        <tr>
+                            <td colspan="2">Insight</td>
+                        </tr>
+                        <tr>
+                            <td colspan="2">{% stat_graphic pokemon.base_insight pokemon.max_insight %}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -131,14 +147,17 @@
                         </tr>
                         {% for move in moveset %}
                         <tr>
-                            <td>{{ move.move.name }}</td>
+                            <td title="{{ move.move.effect }}">{{ move.move.name }}</td>
                             <td>{{ move.learned }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
+                <div class="links">
+                    <a class="back-link" href="javascript:history.back()"><< Back</a>
+                    <a class="back-link" href="{% url "all_species" %}"><< Back to species</a>
+                </div>
             </div>
         </div>
-        <a class="back-link" href="{% url "all_species" %}"><< Back to species</a>
     </div>
 </body>

--- a/pokerole_irl/pokerole_app/templatetags/utilities.py
+++ b/pokerole_irl/pokerole_app/templatetags/utilities.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def stat_graphic(base_stat, max_stat):
+    stat_str = ""
+    stat_str += "🔴"*base_stat
+    stat_str += "⚪"*(max_stat-base_stat)
+    return stat_str

--- a/pokerole_irl/pokerole_app/views.py
+++ b/pokerole_irl/pokerole_app/views.py
@@ -5,7 +5,8 @@ from django.contrib.auth import authenticate, login, get_user_model
 
 from django.views.generic import TemplateView, ListView, CreateView, DetailView
 
-from .models import PokemonSpecies, Pokedex
+from .models import PokemonSpecies, Pokedex, Evolution, MoveSet
+
 
 class MainPageView(TemplateView):
     template_name = "index.html"
@@ -26,6 +27,16 @@ class SpeciesDetailView(DetailView):
     template_name = "species.html"
     model = PokemonSpecies
     context_object_name = "pokemon"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["evolutions"] = Evolution.objects.filter(
+            from_species=context["pokemon"])
+        context["preevolution"] = Evolution.objects.filter(
+            to_species=context["pokemon"])
+        context["moveset"] = MoveSet.objects.filter(
+            species=context["pokemon"])
+        return context
 
 
 class RegisterView(CreateView):

--- a/pokerole_irl/static/species-detail.css
+++ b/pokerole_irl/static/species-detail.css
@@ -7,6 +7,7 @@ body {
     padding: 2rem;
     background-color: rgba(100, 100, 100, 0.1);
     border-radius: 2rem;
+    height: fit-content;
 }
 
 .species-detail h2 {
@@ -24,6 +25,12 @@ body {
     padding: 10px;
 }
 
+.species-description .other-info {
+    font-style: italic;
+    margin-left: 1rem;
+    font-size: small;
+}
+
 .species-height-weight {
     display: flex;
     margin-top: 2rem;
@@ -36,8 +43,8 @@ body {
 }
 
 .details-container img {
-    width: 200px;
-    height: 200px;
+    max-height: 200px;
+    max-width: 50%;
     border: 2px solid var(--color-edges);
     background-color: var(--color-secondary);
     padding: 10px;
@@ -96,14 +103,33 @@ body {
     margin-right: 0.5rem;
 }
 
-.move-table td:first-child {
-    padding-right: 2rem;
+.move-table {
+    border: 2px solid var(--color-edges);
+    border-spacing: 0px;
+    border-radius: 10px;
 }
 
-.back-link {
-    position: absolute;
-    bottom: 2rem;
+.move-table td {
+    width: 100%;
+    padding: 0 1rem;
 }
+
+.move-table td:not(:first-of-type) {
+    width: 50%;
+}
+
+.move-table tr:nth-of-type(2n) {
+    background-color: var(--color-secondary);
+}
+
+
+.links {
+    height: 2rem;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+}
+
 
 @media (min-width: 500px) {
     .species-detail {

--- a/pokerole_irl/static/species-detail.css
+++ b/pokerole_irl/static/species-detail.css
@@ -1,0 +1,112 @@
+body {
+    display: flex;
+    justify-content: center;
+}
+
+.species-detail {
+    padding: 2rem;
+    background-color: rgba(100, 100, 100, 0.1);
+    border-radius: 2rem;
+}
+
+.species-detail h2 {
+    font-size: larger;
+    margin: 0.5rem 0;
+}
+
+.details-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.species-description {
+    padding: 10px;
+}
+
+.species-height-weight {
+    display: flex;
+    margin-top: 2rem;
+    justify-content: space-around;
+}
+
+.species-height-weight .header {
+    text-align: center;
+    font-weight: bold;
+}
+
+.details-container img {
+    width: 200px;
+    height: 200px;
+    border: 2px solid var(--color-edges);
+    background-color: var(--color-secondary);
+    padding: 10px;
+    border-radius: 10px;
+}
+
+.species-category {
+    font-style: italic;
+}
+
+.info-body {
+    display: flex;
+}
+
+.info-body .column {
+    width: 50%;
+}
+
+.stat-table {
+    font-variant: small-caps;
+    margin-top: 1rem;
+}
+
+.stat-table .hp-val {
+    padding: 0.5rem;
+    background-color: var(--color-secondary);
+    text-align: center;
+    width: 2rem;
+    border-radius: 0.5rem;
+    font-size: larger;
+    font-weight: bold;
+}
+
+.evolutions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.evolutions li {
+    display: flex;
+    align-items: flex-end;
+    height: fit-content;
+    margin-top: -1rem;
+}
+
+.evolutions img {
+    height: 100%;
+}
+
+.evolutions .evolution-details {
+    font-style: italic;
+}
+
+.evolutions .evolution-details span:not(:last-child) {
+    margin-right: 0.5rem;
+}
+
+.move-table td:first-child {
+    padding-right: 2rem;
+}
+
+.back-link {
+    position: absolute;
+    bottom: 2rem;
+}
+
+@media (min-width: 500px) {
+    .species-detail {
+        width: 500px;
+    }
+}

--- a/pokerole_irl/static/styles.css
+++ b/pokerole_irl/static/styles.css
@@ -34,3 +34,17 @@ body {
 .species-table ul li:not(:last-child)::after {
     content: ", ";
 }
+
+.comma-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.comma-list li {
+    display: inline;
+}
+
+.comma-list li:not(:last-child)::after {
+    content: ", "
+}


### PR DESCRIPTION
A DetailView of the PokemonSpecies model can now be found on the /species url. Well, really, that's the url for the listview, but from here, the DetailView can be reached by clicking the name of a pokemon.

![species_template](https://user-images.githubusercontent.com/38067090/214395706-2d7375f0-ce97-4adc-a571-19002f43a671.PNG)

