### PR TITLE
Reduce the number of queries on pokedex page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Add search fields to some models in django admin.
 
+- Drastically reduce the number of SQL queries when viewing a pokedex.
+
 
 ## 20/6-2023
 

--- a/pokerole_irl/pokerole_app/views/pokedex_views.py
+++ b/pokerole_irl/pokerole_app/views/pokedex_views.py
@@ -84,7 +84,16 @@ class PokedexEntryListView(LoginRequiredMixin, NextPageMixin, ListView):
     def get_queryset(self):
         queryset = super().get_queryset()
         queryset = queryset.filter(
-            pokedex_id=self.kwargs.get("dex_pk")).order_by("number").prefetch_related("species__primary_type", "species__secondary_type")
+            pokedex_id=self.kwargs.get("dex_pk")).order_by("number"
+                                                           ).prefetch_related(
+            "species__primary_type",
+            "species__secondary_type",
+            "species__primary_type__weaknesses",
+            "species__secondary_type__weaknesses",
+            "species__primary_type__immunities",
+            "species__secondary_type__immunities",
+            "species__primary_type__resistances",
+            "species__secondary_type__resistances")
         if search := self.request.GET.get("search"):
             queryset = queryset.filter(species__name__icontains=search)
         if type_query := self.request.GET.getlist("types"):


### PR DESCRIPTION
Previously we queried again and again when displaying weaknesses, resistances and immunities. Now, we prefetch all that, so we can go from ~200 queries to 15.